### PR TITLE
Include license file in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
The terms of the BSD 3 Clause license require the license text be included with all copies of the software.