### PR TITLE
feat(uwa): support pressure and SPL conversions

### DIFF
--- a/arlpy/uwa.py
+++ b/arlpy/uwa.py
@@ -223,3 +223,37 @@ def bubble_soundspeed(void_fraction, c=soundspeed(), c_gas=340, relative_density
     """
     m = _np.sqrt(relative_density)
     return 1/(1/c*_np.sqrt((void_fraction*(c/c_gas)**2*m+(1-void_fraction)/m)*(void_fraction/m+(1-void_fraction)*m)))
+
+def pressure(x, sensitivity, gain, volt_params=None):
+    """Convert the real signal x to an acoustic pressure signal in micropascal.
+    
+    :param x: real signal in voltage or bit depth (number of bits)
+    :param sensitivity: receiving sensitivity in dB re 1V per micropascal
+    :param gain: preamplifier gain in dB
+    :param volt_params: (nbits, v_ref) is used to convert the number of bits 
+        to voltage where nbits is the number of bits of each sample and v_ref 
+        is the reference voltage, default to None  
+    :returns: acoustic pressure signal micropascal
+    
+    If `volt_params` is provided, the sample unit of x is in number of bits,
+    else is in voltage.  
+    """
+    nu = 10**(sensitivity/20)
+    G = 10**(gain/20)
+    if volt_params is not None:
+        nbits, v_ref = volt_params   
+        x = x*v_ref/(2**(nbits-1))
+    return x/(nu*G)
+
+def spl(x, ref=1):
+    """Get Sound Pressure Level (SPL) of the acoustic pressure signal x.
+    
+    :param x: acoustic pressure signal in micropascal
+    :param ref: reference acoustic pressure in micropascal, default to 1
+    :returns: SPL in dB
+    
+    In water, the common reference is 1 micropascal. In air, the common
+    reference is 20 micropascal.
+    """
+    rmsx = _np.power(_np.mean(_np.power(x, 2)), 1/2)
+    return 20*_np.log10(rmsx/ref)

--- a/arlpy/uwa.py
+++ b/arlpy/uwa.py
@@ -237,6 +237,16 @@ def pressure(x, sensitivity, gain, volt_params=None):
     
     If `volt_params` is provided, the sample unit of x is in number of bits,
     else is in voltage.  
+
+    >>> import arlpy 
+    >>> nbits = 16
+    >>> V_ref = 1.0 
+    >>> x_volt = V_ref*signal.cw(64, 1, 512)
+    >>> x_bit = x_volt*(2**(nbits-1))
+    >>> sensitivity = 0
+    >>> gain = 0
+    >>> p1 = arlpy.uwa.pressure(x_volt, sensitivity, gain)
+    >>> p2 = arlpy.uwa.pressure(x_bit, sensitivity, gain, volt_params=(nbits, V_ref))
     """
     nu = 10**(sensitivity/20)
     G = 10**(gain/20)
@@ -250,10 +260,15 @@ def spl(x, ref=1):
     
     :param x: acoustic pressure signal in micropascal
     :param ref: reference acoustic pressure in micropascal, default to 1
-    :returns: SPL in dB
+    :returns: average SPL in dB re micropascal
     
     In water, the common reference is 1 micropascal. In air, the common
     reference is 20 micropascal.
+
+    >>> import arlpy
+    >>> p = signal.cw(64, 1, 512)
+    >>> arlpy.uwa.spl(p)
+    -3.0103
     """
-    rmsx = _np.power(_np.mean(_np.power(x, 2)), 1/2)
+    rmsx = _np.sqrt(_np.mean(_np.power(_np.abs(x), 2)))
     return 20*_np.log10(rmsx/ref)

--- a/arlpy/uwa.py
+++ b/arlpy/uwa.py
@@ -233,7 +233,7 @@ def pressure(x, sensitivity, gain, volt_params=None):
     :param volt_params: (nbits, v_ref) is used to convert the number of bits 
         to voltage where nbits is the number of bits of each sample and v_ref 
         is the reference voltage, default to None  
-    :returns: acoustic pressure signal micropascal
+    :returns: acoustic pressure signal in micropascal
     
     If `volt_params` is provided, the sample unit of x is in number of bits,
     else is in voltage.  

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -143,6 +143,21 @@ class UwaTestSuite(MyTestCase):
         self.assertApproxEqual(uwa.bubble_soundspeed(0, 1500), 1500)
         self.assertApproxEqual(uwa.bubble_soundspeed(1e-5, 1500), 1372)
         self.assertApproxEqual(uwa.bubble_soundspeed(1, 1500, 330), 330)
+    
+    def test_pressure(self):
+        nbits = 16
+        V_ref = 1.0 
+        x_volt = V_ref*signal.cw(64, 1, 512)
+        x_bit = x_volt*(2**(nbits-1))
+        sensitivity = 0
+        gain = 0
+        p1 = uwa.pressure(x_volt, sensitivity, gain)
+        p2 = uwa.pressure(x_bit, sensitivity, gain, volt_params=(nbits, V_ref))
+        self.assertArrayEqual(p1, p2)
+    
+    def test_spl(self):
+        p = signal.cw(64, 1, 512)
+        self.assertApproxEqual(uwa.spl(p), 20*np.log10(1/np.sqrt(2)))
 
 class SignalTestSuite(MyTestCase):
 


### PR DESCRIPTION
Pressure and Sound Pressure Level (SPL) conversions of a signal have been included.

This would be useful for acoustic receiver calibrations, underwater soundscape monitoring, etc.