### PR TITLE
update subprocess call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# bellhop
+bellhop.exe
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/arlpy/uwapm.py
+++ b/arlpy/uwapm.py
@@ -624,7 +624,9 @@ class _Bellhop:
 
     def _bellhop(self, *args):
         try:
-            _proc.call(['bellhop.exe'] + list(args), stderr=_proc.STDOUT)
+            _proc.run(f'./bellhop.exe {" ".join(list(args))}', 
+                      stderr=_proc.STDOUT, stdout=_proc.PIPE,
+                      shell=True)
         except OSError:
             return False
         return True


### PR DESCRIPTION
Subprocess management recommends using the `run` over `call`

> The recommended approach to invoking subprocesses is to use the [run()](https://docs.python.org/3/library/subprocess.html#subprocess.run) function for all use cases it can handle.

the call function was producing error in my Linux environment, can provide details upon request. 