### PR TITLE
Max depth of acoustic domain

### DIFF
--- a/arlpy/uwapm.py
+++ b/arlpy/uwapm.py
@@ -657,8 +657,10 @@ class _Bellhop:
         self._print(fh, "%0.6f" % (env['frequency']))
         self._print(fh, "1")
         svp = env['soundspeed']
+        svp_depth = 0.0
         svp_interp = 'S' if env['soundspeed_interp'] == spline else 'C'
         if isinstance(svp, _pd.DataFrame):
+            svp_depth = svp.index[-1]
             if len(svp.columns) > 1:
                 svp_interp = 'Q'
             else:
@@ -668,7 +670,8 @@ class _Bellhop:
         else:
             self._print(fh, "'%cVWT*'" % svp_interp)
             self._create_bty_ati_file(fname_base+'.ati', env['surface'], env['surface_interp'])
-        max_depth = env['depth'] if _np.size(env['depth']) == 1 else _np.max(env['depth'][:,1])
+        #max depth should be the depth of the acoustic domain, which can be deeper than the max depth bathymetry
+        max_depth = env['depth'] if _np.size(env['depth']) == 1 else max(_np.max(env['depth'][:,1]), svp_depth)
         self._print(fh, "1 0.0 %0.6f" % (max_depth))
         if _np.size(svp) == 1:
             self._print(fh, "0.0 %0.6f /" % (svp))

--- a/arlpy/uwapm.py
+++ b/arlpy/uwapm.py
@@ -777,8 +777,7 @@ class _Bellhop:
                     for m in range(rx_range_count):
                         count = int(f.readline())
                         for n in range(count):
-                            dataA = self._readf(f, (float, float, float, float, float))
-                            dataB = self._readf(f, (float, int, int))
+                            data = self._readf(f, (float, float, float, float, float, float, int, int))
                             arrivals.append(_pd.DataFrame({
                                 'tx_depth_ndx': [j],
                                 'rx_depth_ndx': [k],
@@ -787,12 +786,12 @@ class _Bellhop:
                                 'rx_depth': [rx_depth[k]],
                                 'rx_range': [rx_range[m]],
                                 'arrival_number': [n],
-                                'arrival_amplitude': [dataA[0]*_np.exp(1j*dataA[1])],
-                                'time_of_arrival': [dataA[2]],
-                                'angle_of_departure': [dataA[4]],
-                                'angle_of_arrival': [dataB[0]],
-                                'surface_bounces': [dataB[1]],
-                                'bottom_bounces': [dataB[2]]
+                                'arrival_amplitude': [data[0]*_np.exp(1j*data[1])],
+                                'time_of_arrival': [data[2]],
+                                'angle_of_departure': [data[4]],
+                                'angle_of_arrival': [data[5]],
+                                'surface_bounces': [data[6]],
+                                'bottom_bounces': [data[7]]
                             }, index=[len(arrivals)+1]))
         return _pd.concat(arrivals)
 

--- a/arlpy/uwapm.py
+++ b/arlpy/uwapm.py
@@ -777,7 +777,8 @@ class _Bellhop:
                     for m in range(rx_range_count):
                         count = int(f.readline())
                         for n in range(count):
-                            data = self._readf(f, (float, float, float, float, float, float, int, int))
+                            dataA = self._readf(f, (float, float, float, float, float))
+                            dataB = self._readf(f, (float, int, int))
                             arrivals.append(_pd.DataFrame({
                                 'tx_depth_ndx': [j],
                                 'rx_depth_ndx': [k],
@@ -786,12 +787,12 @@ class _Bellhop:
                                 'rx_depth': [rx_depth[k]],
                                 'rx_range': [rx_range[m]],
                                 'arrival_number': [n],
-                                'arrival_amplitude': [data[0]*_np.exp(1j*data[1])],
-                                'time_of_arrival': [data[2]],
-                                'angle_of_departure': [data[4]],
-                                'angle_of_arrival': [data[5]],
-                                'surface_bounces': [data[6]],
-                                'bottom_bounces': [data[7]]
+                                'arrival_amplitude': [dataA[0]*_np.exp(1j*dataA[1])],
+                                'time_of_arrival': [dataA[2]],
+                                'angle_of_departure': [dataA[4]],
+                                'angle_of_arrival': [dataB[0]],
+                                'surface_bounces': [dataB[1]],
+                                'bottom_bounces': [dataB[2]]
                             }, index=[len(arrivals)+1]))
         return _pd.concat(arrivals)
 


### PR DESCRIPTION
**Current behavior:**

When providing a sound speed profile as a pandas DetaFrame, and a bathymetry as a list. The environment file created takes the maximum bathymetric depth as the depth of the acoustic domain. Sometimes the sound speed profile is specified at depths deeper than the bathymetry which leads to the SSPFile not initiating properly:
```
At line 879 of file sspMod.f90 (unit=5, file='tmp.env')
Fortran runtime error: Bad al number in item 1 of list input
```

**Change:**
Allows for the SSPFile to have a deeper value than `max_depth` defined by only the BTYFile. Fixing the error of current behavior. 