### PR TITLE
Fixes org-arl/arlpy#84

### DIFF
--- a/arlpy/plot.py
+++ b/arlpy/plot.py
@@ -58,7 +58,7 @@ def _new_figure(title, width, height, xlabel, ylabel, xlim, ylim, xtype, ytype, 
         interactive = _interactive
     if interactive:
         tools = 'pan,box_zoom,wheel_zoom,reset,save'
-    f = _bplt.figure(title=title, plot_width=width, plot_height=height, x_range=xlim, y_range=ylim, x_axis_label=xlabel, y_axis_label=ylabel, x_axis_type=xtype, y_axis_type=ytype, tools=tools)
+    f = _bplt.figure(title=title, width=width, height=height, x_range=xlim, y_range=ylim, x_axis_label=xlabel, y_axis_label=ylabel, x_axis_type=xtype, y_axis_type=ytype, tools=tools)
     f.toolbar.logo = None
     return f
 
@@ -658,7 +658,7 @@ def specgram(x, fs=2, nfft=None, noverlap=None, colormap='Plasma256', clim=None,
         clim = (_np.max(Sxx)-clim, _np.max(Sxx))
     image(Sxx, x=(t[0], t[-1]), y=(f[0], f[-1]), title=title, colormap=colormap, clim=clim, clabel=clabel, xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim, width=width, height=height, hold=hold, interactive=interactive)
 
-def psd(x, fs=2, nfft=512, noverlap=None, window='hanning', color=None, style='solid', thickness=1, marker=None, filled=False, size=6, title=None, xlabel='Frequency (Hz)', ylabel='Power spectral density (dB/Hz)', xlim=None, ylim=None, width=None, height=None, legend=None, hold=False, interactive=None):
+def psd(x, fs=2, nfft=512, noverlap=None, window='hann', color=None, style='solid', thickness=1, marker=None, filled=False, size=6, title=None, xlabel='Frequency (Hz)', ylabel='Power spectral density (dB/Hz)', xlim=None, ylim=None, width=None, height=None, legend=None, hold=False, interactive=None):
     """Plot power spectral density of a given time series signal.
 
     :param x: time series signal


### PR DESCRIPTION
I had tested this with newer python version `python=3.11` and it looks like the issue has been resolved with these changes.

This PR updates the arlpy library to ensure compatibility with Bokeh version 3.1.1 and the latest version of Scipy version 1.10.1. The changes include:

Replaced `plot_width` with `width` and `plot_height` with `height` in all instances where Bokeh figures are created or modified. This change was necessary due to updates in the Bokeh API between version 2.x.x and 3.1.1. In the newer version, the `plot_width` and `plot_height` attributes have been replaced with `width` and `height` respectively.

Updated the default window name in the psd function from 'hanning' to 'hann'. This change was necessary due to updates in the Scipy library, as described in the [Scipy documentation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.welch.html#scipy-signal-welch).

Fixes #84 .