### PR TITLE
Updating detection logic for ipython

### DIFF
--- a/arlpy/plot.py
+++ b/arlpy/plot.py
@@ -39,8 +39,7 @@ _static_images = False
 _colors = light_palette
 
 try:
-    get_ipython                     # check if we are using IPython
-    assert "ipykernel_launcher.py" in _sys.argv[0]   # and Jupyter
+    assert 'ZMQInteractiveShell' in get_ipython().__class__.__name__   # check if we are using IPython and Jupyter
     _bplt.output_notebook(resources=_bres.INLINE, hide_banner=True)
     _notebook = True
 except:


### PR DESCRIPTION
If arlpy is imported by a script run using `%run` in Jupyter, then the `_sys.argv[0]` doesn't seem to contain `ipykernel_launcher` anymore, but contains the name of the script being run.

Looking for `ZMQInteractiveShell` in `get_ipython().__class__.__name__` seems to be a much more reliable way to figure out if we're inside a `Jupyter` session