### PR TITLE
Fix bellhop detection

### DIFF
--- a/arlpy/uwapm.py
+++ b/arlpy/uwapm.py
@@ -624,9 +624,11 @@ class _Bellhop:
 
     def _bellhop(self, *args):
         try:
-            _proc.run(f'bellhop.exe {" ".join(list(args))}', 
-                      stderr=_proc.STDOUT, stdout=_proc.PIPE,
-                      shell=True)
+            result = _proc.run(f'bellhop.exe {" ".join(list(args))}', 
+                        stderr=_proc.STDOUT, stdout=_proc.PIPE,
+                        shell=True)
+            if result.returncode == 127:
+                return False
         except OSError:
             return False
         return True

--- a/tests/context.py
+++ b/tests/context.py
@@ -6,6 +6,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from arlpy import utils
 from arlpy import geo
 from arlpy import uwa
+from arlpy import uwapm
 from arlpy import signal
 from arlpy import comms
 from arlpy import bf

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -9,10 +9,11 @@
 ##############################################################################
 
 import unittest
+import os
 import numpy as np
 import scipy.signal as sp
 
-from .context import utils, geo, uwa, signal, comms, bf
+from .context import utils, geo, uwa, uwapm, signal, comms, bf
 
 class MyTestCase(unittest.TestCase):
 
@@ -159,6 +160,15 @@ class UwaTestSuite(MyTestCase):
         p = signal.cw(64, 1, 512)
         self.assertApproxEqual(uwa.spl(p), 20*np.log10(1/np.sqrt(2)))
 
+class UwapmTestSuite(MyTestCase):
+
+    def test_no_models(self):
+        # Remove old PATH so it doesn't conflict with the test.
+        # It will get reset in the next test.
+        os.environ["PATH"] = ""
+
+        self.assertEqual(uwapm.models(), [])
+        
 class SignalTestSuite(MyTestCase):
 
     def test_time(self):


### PR DESCRIPTION
There was a problem where Bellhop was not correctly detected in the `_bellhop` function. More specifically, it shows up as a possible model even if it is not on the path. To reproduce, ensure Bellhop is not in your path and then run `uwapm.models()`. Bellhop appears in the list even though it is not on the path. Here is a demonstration:

<img width="822" alt="Screenshot 2024-02-22 at 9 12 40 AM" src="https://github.com/org-arl/arlpy/assets/1527647/2a1270a3-674e-4879-8bdb-569657c99fa8">

The problem is that the return code of the subprocess command needs to be checked. I added code to check the return code and added a test.