### PR TITLE
Added fname_base feature

### DIFF
--- a/arlpy/uwapm.py
+++ b/arlpy/uwapm.py
@@ -323,7 +323,7 @@ def compute_arrivals(env, model=None, debug=False, fname_base=None):
     (model_name, model) = _select_model(env, arrivals, model)
     if debug:
         print('[DEBUG] Model: '+model_name)
-    return model.run(env, arrivals, debug)
+    return model.run(env, arrivals, debug, fname_base)
 
 def compute_eigenrays(env, tx_depth_ndx=0, rx_depth_ndx=0, rx_range_ndx=0, model=None, debug=False, fname_base=None):
     """Compute eigenrays between a given transmitter and receiver.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-with open('README.rst') as f:
+with open('README.md') as f:
     readme = f.read()
 
 setup(


### PR DESCRIPTION
I've played around with adding a feature where you can pass a custom file name to the model, and it will use this instead of the temp files. The default is None, which uses the temp files as normal.

Example usage (works with compute_arrivals, compute_transmission_loss, compute_rays)
```
arrivals = pm.compute_eigenrays(env, fname_base='test')
```
printed output:
[CUSTOM FILES] Bellhop working files: arlpy_test.*

Let me know what you think!

